### PR TITLE
Fix CMakeLists for Ubuntu 16.04 to link OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,15 @@ find_package(Boost 1.65.0 COMPONENTS system filesystem REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIR})
 
-if(APPLE)
+if(NOT WIN32)
     find_package(OpenGL REQUIRED)
     if(OPENGL_FOUND)
         message("OpenGL Found")
     endif()
-    include_directories(${OPENGL_INCLUDE_DIRS})
+
+    if (APPLE)
+        include_directories(${OPENGL_INCLUDE_DIRS})
+    endif()
 endif()
 
 find_package(GLEW REQUIRED)


### PR DESCRIPTION
Fixes https://github.com/ecsex46/fall-2019/issues/1 by always running `find_package(OpenGL REQUIRED)` on Linux machines, not just exclusively Apple machines.

Please ensure this works with different OS environments, I'm limited to my Ubuntu 16.04 machine. I had to cherry-pick this commit on my private mirror of the tinyrender in order to compile the project on my machine.